### PR TITLE
Add scroll-snap styles for scrolling madness

### DIFF
--- a/aprilFools.css
+++ b/aprilFools.css
@@ -10,6 +10,14 @@
   They will be applied to every website they visit as well as their developer tools.
 */
 
+/*
+   Force the browser to scroll more than the page height making 
+   some content unavailable through normal scroll
+ */
+*,::before,::after {
+  scroll-snap-points-y: repeat(110%);
+  scroll-snap-type: mandatory;
+}
 
 /*
   Turn every website upside down


### PR DESCRIPTION
We are getting close to april fools day again, and I thought it was time to get a new april fools gag in =)

You can test it by going into the dev tools and just applying the style to the html node to make the page scroll more than one page height at a time. The reason to use wildcards is that this will also catch containers within the page (like the github text editors)